### PR TITLE
Basic Debug Toolchain

### DIFF
--- a/source/application/main.lua
+++ b/source/application/main.lua
@@ -3,9 +3,13 @@
 
 -- This is the actual start file. (../core/dashboard/main.lua) is still enforced so, we're forced to use it. 
 
+-- Essential Debug Utilities
 
--- Essential Debug
-require("tevgit:source/application/utilities/reload.lua")
+-- If Tevgit is overridden
+if core.dev.localTevGit then
+    require("tevgit:source/application/utilities/debug/output.lua")
+    require("tevgit:source/application/utilities/debug/keybinds.lua")
+end
 
 -- List of stuff that updates
 require("tevgit:source/application/updater/main.lua")

--- a/source/application/updater/main.lua
+++ b/source/application/updater/main.lua
@@ -11,6 +11,8 @@
     Dark Grey: 666666 // 102, 102, 102
     Light Blue: 679bce // 103, 155, 206
     Purple: 6767ce // 103, 103, 206
+    Orange: ff8a65 // 255, 138, 101
+    Yellow: ffb74d // 255, 183, 77
 ]]--
 
 local Container = core.construct("guiFrame", {
@@ -100,7 +102,7 @@ if core.dev.localTevGit then
         position = guiCoord(0.5, -150, 0.64, 10),
         backgroundColour = colour.rgb(246, 248, 250),
         backgroundAlpha = 1,
-        text = "/Users/sanjaybhadra/Desktop/deviap-main",
+        text = "/Users/username/Desktop/deviap-main",
         textColour = colour.rgb(1, 1, 1),
         textAlign = "middle",
         textSize = 15,

--- a/source/application/updater/main.lua
+++ b/source/application/updater/main.lua
@@ -78,7 +78,7 @@ sleep(1)
 
 
 -- If Tevgit is overridden
-if not core.dev.localTevGit then
+if core.dev.localTevGit then
 
     core.construct("guiTextBox", {
         parent = Container,
@@ -110,7 +110,7 @@ if not core.dev.localTevGit then
 end
 
 -- If barebones application
-if core.dev.localTevGit then
+if not core.dev.localTevGit then
     
     local infoLabel = core.construct("guiTextBox", {
         parent = Container,

--- a/source/application/utilities/debug/keybinds.lua
+++ b/source/application/utilities/debug/keybinds.lua
@@ -1,0 +1,24 @@
+-- Copyright 2020 - Deviap (deviap.com)
+-- Author(s): Sanjay-B(Sanjay)
+
+-- All keybinds used for debugging internally.
+
+local graphicsDebug = false
+core.input:on("keyDown", function(key)
+
+    -- Output Window Enable / Disable
+    if key == "KEY_F1" then core.interface:child("outputWindow").visible = not core.interface:child("outputWindow").visible
+
+    -- Hard Reset Application
+    elseif key == "KEY_F2" then core.apps:reset()
+
+    -- Prompts Tevgit
+    elseif key == "KEY_F3" then core.dev:promptTevGit()
+
+    -- Hard Reload Shaders
+    elseif key == "KEY_F4" then core.dev:reloadAllShaders()
+
+    -- Graphics Debug Enable / Disable
+    elseif key == "KEY_F5" then graphicsDebug = not graphicsDebug core.graphics:setDebug(graphicsDebug)
+    end
+end)

--- a/source/application/utilities/debug/output.lua
+++ b/source/application/utilities/debug/output.lua
@@ -1,0 +1,122 @@
+-- Copyright 2020 - Deviap (deviap.com)
+-- Author(s): Sanjay-B(Sanjay), utrain
+
+-- Output for internal debug purposes.
+
+local maxEntries = 19
+local debounce, contents = false, {}
+local Container = core.construct("guiFrame", {
+    parent = core.interface,
+    name = "outputWindow", -- So, we can reference this later.
+    size = guiCoord(0, math.max(core.coreInterface.absoluteSize.x/3,150), 0, math.max(core.coreInterface.absoluteSize.y/3,200)),
+    position = guiCoord(0, 0, 0, 0),
+    backgroundColour = colour(1, 1, 1),
+    strokeWidth = 2,
+    strokeColour = colour(0.75, 0.75, 0.75),
+    strokeAlpha = 1,
+    strokeRadius = 2,
+    visible = true,
+    zIndex = 200
+})
+
+local topBar = core.construct("guiFrame", {
+    parent = Container,
+    size = guiCoord(1, 0, 0, 20),
+    backgroundColour = colour(0.75, 0.75, 0.75)
+})
+
+local headerText = core.construct("guiTextBox", {
+    parent = Container,
+    size = guiCoord(1, 0, 1, 0),
+    position = guiCoord(0, 0, 0, 0),
+    backgroundAlpha = 0,
+    text = " Console",
+    textFont = "tevurl:fonts/openSansBold.ttf",
+    textMultiline = true,
+    textWrap = true
+})
+
+local scrollContents = core.construct("guiScrollView", {
+    parent = Container,
+    size = guiCoord(1, 0, 1, -20),
+    position = guiCoord(0, 0, 0, 20),
+    backgroundColour = colour.rgb(255, 255, 255),
+    backgroundAlpha = 1,
+    scrollbarAlpha = 0.8,
+    scrollbarColour = colour(0.75, 0.75, 0.75),
+    scrollbarRadius = 0,
+    scrollbarWidth = 5,
+    active = true
+})
+
+-- Console Move Logic
+local down = headerText:on("mouseLeftDown", function(initialPosition)
+
+    if debounce then return end
+    debounce = true
+
+    local offset = initialPosition-Container.absolutePosition
+
+    move = core.input:on("mouseMoved", function()
+        Container.position = guiCoord(0, core.input.mousePosition.x-offset.x, 0, core.input.mousePosition.y-offset.y)
+    end)
+
+    release = core.input:on("mouseLeftUp", function()
+        core.disconnect(move)
+        core.disconnect(release)
+        core.disconnect(down)
+        debounce = false
+    end)
+end)
+
+
+-- Contents Population Logic
+-- RED: colour.rgb(229, 115, 115)
+-- GREY: colour.rgb(102, 102, 102)
+core.debug:on("print", function(message)
+    contents[#contents+1] = {
+        ["message"] = os.date("%H:%M:%S", os.time())..": "..message,
+        ["colour"] = (string.match(message, "ERROR:") and colour.rgb(229, 115, 115) or colour.rgb(102, 102, 102))
+    }
+end)
+
+core.debug:on("warn", function(message)
+    contents[#contents+1] = {
+        ["message"] = os.date("%H:%M:%S", os.time())..": "..message,
+        ["colour"] = colour.rgb(255, 183, 77)
+    }
+end)
+
+-- error(message) doesn't invoke this so, it's disabled until it's fixed.
+--[[
+core.debug:on("error", function(message)
+    contents[#contents+1] = {
+        ["message"] = os.date("%H:%M:%S", os.time())..": "..message,
+        ["colour"] = colour.rgb(229, 115, 115)
+    }
+end)
+]]--
+
+-- Update Console Contents
+spawn(function()
+    while sleep(0.3) do
+        scrollContents:destroyChildren()
+        scrollContents.canvasSize = guiCoord(1, 0, 0, 0)
+        for index, data in pairs(contents) do
+            local textLabel = core.construct("guiTextBox", {
+                parent = scrollContents,
+                size = guiCoord(1, 0, 1, 0),
+                position = guiCoord(0, 0, 0, scrollContents.canvasSize.offset.y);
+                backgroundColour = colour.rgb(255, 255, 255),
+                text = data["message"],
+                textColour = data["colour"],
+                textFont = "tevurl:fonts/firaCodeBold.otf",
+                textSize = 14,
+                textWrap = true,
+                visible = true
+            })
+            textLabel.size = guiCoord(1, 0, 0, textLabel.textDimensions.y+2)
+            scrollContents.canvasSize = scrollContents.canvasSize+guiCoord(0, 0, 0, textLabel.absoluteSize.y)
+        end
+    end
+end)

--- a/source/application/utilities/reload.lua
+++ b/source/application/utilities/reload.lua
@@ -1,7 +1,0 @@
--- Copyright 2020 - Deviap (deviap.com)
--- Author(s): Sanjay-B(Sanjay)
-
--- Temporary file. Force reloads Deviap. 
-core.input:on("keyDown", function(key)
-    if key == "KEY_TAB" then core.apps:reset() end
-end)


### PR DESCRIPTION
This is only enabled when Tevgit has been overridden by a local directory. This is mainly used for internal development. For the average user on the platform, they will not use these tools or see it. 

A system of keybinds has been implemented loosely to help with the toolchain functionality. Keys are binded to the function keys. If you're on macOS w/ a touchbar, you can use these tools by doing ``fn + F#`` where ``#`` represents a number between ``1 - 12``. 

The debug toolchain introduces an output window that's colored based on the message displayed. 
- Info Messages (print statements) are grey. 
- Warn Messages (warn statements) are yellowish orange.
- Error Messages (errors within your code) are terra cotta. 

The following function keys are introduced.
- ``F1`` - Output Window Enable / Disable.
- ``F2`` - Hard Reset Application.
- ``F3`` - Prompts Tevgit.
- ``F4`` - Hard Reload Shaders.
- ``F5`` - Graphics Debug Enable / Disable.

> Note: Output window will be converted to a component once the component system has been implemented. 