### PR TITLE
Unlock tevgit override to Default client

### DIFF
--- a/source/application/main.lua
+++ b/source/application/main.lua
@@ -4,12 +4,8 @@
 -- This is the actual start file. (../core/dashboard/main.lua) is still enforced so, we're forced to use it. 
 
 -- Essential Debug Utilities
-
--- If Tevgit is overridden
-if core.dev.localTevGit then
-    require("tevgit:source/application/utilities/debug/output.lua")
-    require("tevgit:source/application/utilities/debug/keybinds.lua")
-end
+require("tevgit:source/application/utilities/debug/output.lua")
+require("tevgit:source/application/utilities/debug/keybinds.lua")
 
 -- List of stuff that updates
 require("tevgit:source/application/updater/main.lua")

--- a/source/application/utilities/debug/keybinds.lua
+++ b/source/application/utilities/debug/keybinds.lua
@@ -1,24 +1,26 @@
 -- Copyright 2020 - Deviap (deviap.com)
 -- Author(s): Sanjay-B(Sanjay)
 
--- All keybinds used for debugging internally.
+-- All keybinds used for debugging internally. Tevgit has to be overridden to enable all but the Tevgit Prompt
 
 local graphicsDebug = false
+if core.dev.localTevGit then core.interface:child("outputWindow").visible = true end -- Set to true if tevgit is overridden, otherwise hide it.
+
 core.input:on("keyDown", function(key)
 
     -- Output Window Enable / Disable
-    if key == "KEY_F1" then core.interface:child("outputWindow").visible = not core.interface:child("outputWindow").visible
+    if key == "KEY_F1" and core.dev.localTevGit then core.interface:child("outputWindow").visible = not core.interface:child("outputWindow").visible
 
     -- Hard Reset Application
-    elseif key == "KEY_F2" then core.apps:reset()
+    elseif key == "KEY_F2" and core.dev.localTevGit then core.apps:reset()
 
     -- Prompts Tevgit
     elseif key == "KEY_F3" then core.dev:promptTevGit()
 
     -- Hard Reload Shaders
-    elseif key == "KEY_F4" then core.dev:reloadAllShaders()
+    elseif key == "KEY_F4" and core.dev.localTevGit then core.dev:reloadAllShaders()
 
     -- Graphics Debug Enable / Disable
-    elseif key == "KEY_F5" then graphicsDebug = not graphicsDebug core.graphics:setDebug(graphicsDebug)
+    elseif key == "KEY_F5" and core.dev.localTevGit then graphicsDebug = not graphicsDebug core.graphics:setDebug(graphicsDebug)
     end
 end)

--- a/source/application/utilities/debug/output.lua
+++ b/source/application/utilities/debug/output.lua
@@ -15,7 +15,7 @@ local Container = core.construct("guiFrame", {
     strokeColour = colour(0.75, 0.75, 0.75),
     strokeAlpha = 1,
     strokeRadius = 2,
-    visible = true,
+    visible = false,
     zIndex = 200
 })
 


### PR DESCRIPTION
``F2`` can now be used on the default client to override the client source files. Standardized to how it was before the rebrand. 